### PR TITLE
ndarray-stats

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -123,6 +123,9 @@
 
 - name: ndarray-linalg
   topics: ["scientific-computing"]
+  
+- name: ndarray-stats
+  topics: ["scientific-computing"]
 
 - name: neuroflow
   topics: ["neural-networks"]


### PR DESCRIPTION
I have added [`ndarray-stats`](https://crates.io/crates/ndarray-stats) to the scientific computing section.