### PR TITLE
Mention evcxr instead of rusti and jupyter-rs

### DIFF
--- a/_topics/scientific-computing.md
+++ b/_topics/scientific-computing.md
@@ -11,10 +11,8 @@ But it's still too early to know which crates will emerge as
 central to a robust scientific computing ecosystem.
 
 Given the value of iterative analysis in scientific computing,
-it's worth checking out [rusti REPL](https://github.com/murarth/rusti).
-There was some progress on a [Jupyter backend for Rust](https://github.com/pwoolcoc/jupyter-rs)
-but it seems to have stalled. You can also find a relevant rusti issue
-tracking this [here](https://github.com/murarth/rusti/issues/43).
+it's worth checking out [Evcxr REPL](https://github.com/google/evcxr/blob/master/evcxr_repl/).
+There is also a [Jupyter backend for Rust](https://github.com/google/evcxr/tree/master/evcxr_jupyter/).
 
 Also, check out some of these resources:
 


### PR DESCRIPTION
rusti requires a nightly compiler from 2016 and jupyter-rs is abandoned.