### PR TITLE
Add the tch crate.

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -209,6 +209,9 @@
 - name: sprs
   topics: ["data-structures", "scientific-computing"]
 
+- name: tch
+  topics: ["neural-networks", "bindings"]
+
 - name: tensorflow
   topics: ["neural-networks", "bindings"]
 


### PR DESCRIPTION
This adds the [tch](https://github.com/LaurentMazare/tch-rs) crate which provides bindings for PyTorch for rust. The bindings are advanced enough so that you can train a LSTM on text data or a ResNet on some image dataset.