### PR TITLE
Add crate: linfa

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -137,6 +137,9 @@
 - name: leaf
   topics: ["neural-networks"]
 
+- name: linfa
+  topics: ["clustering"]
+
 - name: linxal
   topics: ["scientific-computing"]
 


### PR DESCRIPTION
From the repo: "[`linfa`](https://github.com/LukeMathWalker/linfa) aims to provide a comprehensive toolkit to build Machine Learning applications with Rust." Currently it just implements k-means clustering. 

Related blog post by the creator: [Taking ML to production with Rust: a 25x speedup](https://www.lpalmieri.com/posts/2019-12-01-taking-ml-to-production-with-rust-a-25x-speedup/)