### PR TITLE
Add and reorganize crates

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -85,9 +85,6 @@
 - name: datafusion
   topics: ["data-preprocessing"]
 
-- name: forester
-  topics: ["decision-trees"]
-
 - name: densearray
   topics: ["data-structures"]
 
@@ -118,6 +115,9 @@
 
 - name: fann
   topics: ["neural-networks"]
+
+- name: forester
+  topics: ["decision-trees"]
 
 - name: genetic
   topics: ["metaheuristics"]

--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -128,6 +128,9 @@
 - name: hal-ml
   topics: ["neural-networks"]
 
+- name: hdf5
+  topics: ["data-preprocessing"]
+
 - name: juice
   topics: ["neural-networks"]
 
@@ -279,6 +282,12 @@
 
 - name: vulkano
   topics: ["gpu-computing"]
+
+- name: whitenoise_runtime
+  topics: ["data-preprocessing"]
+
+- name: whitenoise_validator
+  topics: ["data-preprocessing"]
 
 - name: xgboost
   topics: ["decision-trees"]

--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -286,12 +286,6 @@
 - name: vulkano
   topics: ["gpu-computing"]
 
-- name: whitenoise_runtime
-  topics: ["data-preprocessing"]
-
-- name: whitenoise_validator
-  topics: ["data-preprocessing"]
-
 - name: xgboost
   topics: ["decision-trees"]
   description: "Rust bindings for the XGBoost gradient boosted trees library."
@@ -320,3 +314,8 @@
 - repository: https://github.com/NivenT/REnforce
   description: "Reinforcement library written in Rust"
   topics: ["reinforcement"]
+
+- repository: https://github.com/opendifferentialprivacy/whitenoise-core
+  description: "Differential privacy validator and runtime"
+  license: MIT
+  topics: ["data-preprocessing"]

--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -88,6 +88,9 @@
 - name: densearray
   topics: ["data-structures"]
 
+- name: drug
+  topics: ["neural-networks"]
+
 - name: em
   description: "A macro for executing a subset of Rust with OpenCL"
   topics: ["gpu-computing", "scientific-computing"]


### PR DESCRIPTION
I added a few crates to the list:
- `hdf5`: an HDF5 crate
- `drug`: a neural network crate. (Closes #30.)
- [WhiteNoise Core](https://github.com/opendifferentialprivacy/whitenoise-core): a Rust library for implementing differentially private algorithms and verifying the differential privacy of data analyses. Since this library consists of two crates (for now), I created one entry for the repository. The project's main website is [here](https://opendifferentialprivacy.github.io/).

I also moved `forester` into its correct alphabetical position.