### PR TITLE
Changed front-weight from 300 to 400

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -9,7 +9,7 @@ body {
     color: $text-color;
     font-family: $base-font-family;
     font-size: 1.6em;
-    font-weight: 300;
+    font-weight: 400;
     letter-spacing: 0.01em;
     line-height: 1.6;
 


### PR DESCRIPTION
I visited the site and released the font-weight was set to 300 and as a result the extremely hard to read. Changing to 400 will just fix this.

300 font-weight
![image](https://user-images.githubusercontent.com/23193271/102822897-cc50b800-43d1-11eb-9249-e925820cd515.png)

400 font-weight
![image](https://user-images.githubusercontent.com/23193271/102822939-e094b500-43d1-11eb-9d21-5a02795f0dfa.png)
