### PR TITLE
Add qdrant - a vector similarity search engine

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -229,6 +229,9 @@
 
 - name: qcgpu
   topics: ["scientific-computing"]
+  
+- name: qdrant
+  topics: ["clustering", "data-structures"]
 
 - name: rds
   topics: ["data-structures"]


### PR DESCRIPTION
This adds *qdrant* - a vector similarity search engine with extended filtering support.
Categories are *clustering* and *data-structures* (analog to the crate *faiss*).
URL: https://github.com/qdrant/qdrant
The crate is *not* hosted on crates.io.