### PR TITLE
crates: add wonnx

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -399,7 +399,6 @@
   license: BSD
   topics: ["neural-networks", "linear-classifiers"]
   
-- repository: https://github.com/webonnx/wonnx
-  description: "Wonnx is a GPU-accelerated ONNX inference run-time written 100% in Rust, ready for the web."
-  license: MIT
+- name: wonnx
   topics: ["neural-networks", "gpu-computing"]
+  

--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -364,6 +364,9 @@
 - name: wgpu
   topics: ["gpu-computing"]
 
+- name: wonnx
+  topics: ["neural-networks", "gpu-computing"]  
+
 - repository: https://github.com/torchrs/torchrs
   description: "Torch.rs (torturous) is a set of Rust bindings for torch intended to provide an API very close to that of PyTorch."
   license: BSD-2-Clause
@@ -398,7 +401,3 @@
   description: "Fast logistic regression and field-aware factorization machines in Rust"
   license: BSD
   topics: ["neural-networks", "linear-classifiers"]
-  
-- name: wonnx
-  topics: ["neural-networks", "gpu-computing"]
-  

--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -394,8 +394,12 @@
   license: MIT
   topics: ["data-preprocessing"]
 
-
 - repository: https://github.com/outbrain/fwumious_wabbit
   description: "Fast logistic regression and field-aware factorization machines in Rust"
   license: BSD
   topics: ["neural-networks", "linear-classifiers"]
+  
+- repository: https://github.com/webonnx/wonnx
+  description: "Wonnx is a GPU-accelerated ONNX inference run-time written 100% in Rust, ready for the web."
+  license: MIT
+  topics: ["neural-networks", "gpu-computing"]


### PR DESCRIPTION
wonnx is a very promising GPU inference runtime for neural networks represented in the ONNX format. As it uses wgpu, it can run anywhere where wgpu runs (and the features it requires are available), including the web!