### PR TITLE
Adding burn and rust-gpu

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -46,6 +46,9 @@
 
 - name: blasoxide
   topics: ["scientific-computing"]
+  
+- name: burn
+  topics: ["neural-networks"]
 
 - name: bvh
   topics: ["data-structures"]
@@ -293,7 +296,7 @@
 
 - name: rustacuda
   topics: ["scientific-computing", "gpu-computing"]
-
+  
 - name: rustlearn
   topics: ["linear-classifiers", "decision-trees"]
 
@@ -310,6 +313,11 @@
   documentation: https://athemathmo.github.io/rusty-data/
   topics: ["data-preprocessing"]
 
+- name: rust-gpu
+  repository: https://github.com/embarkstudios/rust-gpu
+  description: "Making Rust a first-class language and ecosystem for GPU graphics & compute shaders"
+  topics: ["gpu-computing"]
+  
 - name: rusty-machine
   topics: ["neural-networks", "linear-classifiers", "clustering"]
 


### PR DESCRIPTION
Adding the burn crate and rust-gpu repository to list. The rust-gpu crate site doesn't appear to be in sync with the repository.