### PR TITLE
Update crate: linfa

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -187,7 +187,8 @@
   topics: ["neural-networks"]
 
 - name: linfa
-  topics: ["clustering"]
+  documentation: "https://rust-ml.github.io/linfa/"
+  topics: ["clustering", "decision-trees", "linear-classifiers"]
 
 - name: linxal
   topics: ["scientific-computing"]


### PR DESCRIPTION
This updates _linfa_, adding documentation (https://rust-ml.github.io/linfa/) and the categories "decision-trees","linear-classifiers". 