### PR TITLE
Adds `cudarc` crate, add categories to `dfdx`

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -94,6 +94,9 @@
 - name: cuda-std
   topics: ["gpu-computing"]
 
+- name: cudarc
+  topics: ["gpu-computing"]
+
 - name: cudnn
   topics: ["gpu-computing"]
 
@@ -117,7 +120,7 @@
   topics: ["data-structures"]
 
 - name: dfdx
-  topics: ["neural-networks", "reinforcement", "linear-classifiers"]
+  topics: ["neural-networks", "reinforcement", "linear-classifiers", "gpu-computing", "scientific-computing"]
 
 - name: drug
   topics: ["neural-networks"]


### PR DESCRIPTION
Hello I'm the author of `cudarc`, which is a wrapper library around cuda.

Also the author of dfdx, and recently GPU support has been added (via cudarc!). So I'm adding gpu-computing tags there