### PR TITLE
Added deep_causality crate and new topic computational-causality

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -116,6 +116,11 @@
 - name: datafusion
   topics: ["data-preprocessing"]
 
+- name: deep_causality
+  description: "Computational causality library. Provides causality graph, collections, context and causal reasoning."
+  documentation: "https://docs.rs/deep_causality"
+  topics: ["computational-causality", "data-structures","scientific-computing"]
+
 - name: densearray
   topics: ["data-structures"]
 

--- a/_data/topics.yaml
+++ b/_data/topics.yaml
@@ -1,4 +1,5 @@
 - clustering
+- computational-causality
 - data-preprocessing
 - data-structures
 - decision-trees

--- a/_scraper/src/data.rs
+++ b/_scraper/src/data.rs
@@ -14,6 +14,7 @@ pub enum Topic {
     DataPreprocessing,
     DataStructures,
     Clustering,
+    ComputationalCausality,
     DecisionTrees,
     LinearClassifiers,
     Reinforcement,

--- a/posts/computational-causality.md
+++ b/posts/computational-causality.md
@@ -1,0 +1,14 @@
+---
+layout: crates.liquid
+title: Computational Causality
+permalink: /causality
+data: {
+    crate_tag: computational-causality,
+    color: blue,
+}
+---
+
+Computational Causality reasons over causal relations encoded in a causal model either without assumptions
+or with explicit and verifiable assumptions about the data. When the underlying assumption are verified, the causal
+model is applicable to the data. This is different from deep learning that uses correlation between input and output 
+and assumes that the data distribution of the trainings data is the same as the data distribution of the production data.


### PR DESCRIPTION
Hi, 

I'm the author of the first computational causality crate for Rust and when I looked  at submitting my crate to this awesome list, it seems no category really fits. 

Therefore, I propose adding a new topic " computational-causality" and added the crate deep_causality.

For background, feel free to read: [How is deep causality different from deep learning?](https://github.com/deepcausality-rs/deep_causality/blob/main/deep_causality/docs/difference.md)

