### PR TITLE
Add candle

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -56,6 +56,11 @@
 - name: bvh
   topics: ["data-structures"]
 
+- name: candle-core
+  repository: https://github.com/huggingface/candle
+  description: "Minimalist ML framework with CUDA acceleration and quantization support"
+  topics: ["neural-networks"]
+  
 - name: cgmath
   topics: ["scientific-computing"]
 


### PR DESCRIPTION
This adds candle to the list of crates, candle is a new set of crates for machine learning [repo](https://github.com/huggingface/candle), the name is `candle-core` to match the actual main crate name.