### PR TITLE
BSD Should be BSD-3-Clause

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -431,5 +431,5 @@
 
 - repository: https://github.com/outbrain/fwumious_wabbit
   description: "Fast logistic regression and field-aware factorization machines in Rust"
-  license: BSD
+  license: BSD-3-Clause
   topics: ["neural-networks", "linear-classifiers"]


### PR DESCRIPTION
The License on [fwumious wabbit](https://github.com/outbrain/fwumious_wabbit) that can be seen [here](https://github.com/outbrain/fwumious_wabbit/blob/main/LICENSE.md) is BSD 3-Clause based on the wikipedia definition [that can be seen here](https://en.wikipedia.org/wiki/BSD_licenses)

```diff
- license: BSD
+ license: BSD-3-Clause
```