### PR TITLE
Add cobyla and slsqp crates

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -77,6 +77,9 @@
 - name: coaster
   topics: ["scientific-computing", "gpu-computing"]
 
+- name: cobyla
+  topics: ["scientific-computing", "metaheuristics"]
+
 - name: cogent
   topics: ["neural-networks"]
 
@@ -350,6 +353,9 @@
 
 - name: simplers_optimization
   topics: ["metaheuristics"]
+
+- name: slsqp
+  topics: ["scientific-computing", "metaheuristics"]
 
 - name: smartcore
   documentation: https://smartcorelib.org/


### PR DESCRIPTION
Those crates are pure Rust implementations of classic (respectively) COBYLA and SLSQP optimizers generated from NLopt 2.7.1 C code using c2rust then hand-edited to make it work.