### PR TITLE
Corrected crate name from triton to triton_grow

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -388,7 +388,8 @@
 - name: tract
   topics: ["neural-networks"]
 
-- name: triton
+- name: triton_grow
+  repository: https://github.com/BradenEverson/triton
   topics: ["neural-networks"]
 
 - name: tvm


### PR DESCRIPTION
Changed crate name from triton to triton_grow, triton is a different crate. Also added repository for triton_grow