### PR TITLE
Add MLOps category

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,13 +72,11 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      -
-        name: Use daily cache of scraper data
+      - name: Use daily cache of scraper data
         uses: actions/cache@v2
         with:
           path: _tmp
           key: scraper-data-cache-${{ steps.date.outputs.date }}
-
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -113,7 +111,7 @@ jobs:
         run: ${{ env.COBALT_BIN }} build
 
       - name: Upload built site archive
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: site-archive
           path: _site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download built site archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: site-archive
           path: _site

--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -60,7 +60,7 @@
   repository: https://github.com/huggingface/candle
   description: "Minimalist ML framework with CUDA acceleration and quantization support"
   topics: ["neural-networks"]
-  
+
 - name: cgmath
   topics: ["scientific-computing"]
 
@@ -131,7 +131,14 @@
   topics: ["data-structures"]
 
 - name: dfdx
-  topics: ["neural-networks", "reinforcement", "linear-classifiers", "gpu-computing", "scientific-computing"]
+  topics:
+    [
+      "neural-networks",
+      "reinforcement",
+      "linear-classifiers",
+      "gpu-computing",
+      "scientific-computing",
+    ]
 
 - name: drug
   topics: ["neural-networks"]
@@ -192,7 +199,7 @@
   topics: ["clustering"]
 
 - name: kmeans-colors
-  topics: ["clustering","scientific-computing"]
+  topics: ["clustering", "scientific-computing"]
 
 - name: kmedoids
   topics: ["clustering"]
@@ -362,7 +369,14 @@
 
 - name: smartcore
   documentation: https://smartcorelib.org/
-  topics: ["data-structures", "linear-classifiers", "clustering", "scientific-computing", "decision-trees"]
+  topics:
+    [
+      "data-structures",
+      "linear-classifiers",
+      "clustering",
+      "scientific-computing",
+      "decision-trees",
+    ]
 
 - name: statrs
   topics: ["scientific-computing"]
@@ -446,3 +460,18 @@
   description: "Fast logistic regression and field-aware factorization machines in Rust"
   license: BSD-3-Clause
   topics: ["neural-networks", "linear-classifiers"]
+
+- repository: https://github.com/tensorzero/tensorzero
+  description: "data & learning flywheel for LLMs that unifies inference, observability, optimization, and experimentation"
+  license: Apache-2.0
+  topics: ["mlops"]
+
+- repository: https://github.com/evilsocket/cake
+  description: "Distributed LLM and StableDiffusion inference for mobile, desktop and server."
+  license: GPL-3.0
+  topics: ["mlops"]
+
+- repository: https://github.com/qdrant/qdrant
+  description: "High-performance, massive-scale Vector Database for the next generation of AI."
+  license: Apache-2.0
+  topics: ["mlops"]

--- a/_data/topics.yaml
+++ b/_data/topics.yaml
@@ -5,6 +5,7 @@
 - gpu-computing
 - linear-classifiers
 - metaheuristics
+- mlops
 - nerual-networks
 - nlp
 - reinforcement-learning

--- a/_scraper/src/data.rs
+++ b/_scraper/src/data.rs
@@ -11,6 +11,7 @@ pub enum Topic {
     GpuComputing,
     NeuralNetworks,
     Metaheuristics,
+    Mlops,
     DataPreprocessing,
     DataStructures,
     Clustering,

--- a/_scraper/src/main.rs
+++ b/_scraper/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> Result<()> {
             .krate
             .as_ref()
             .and_then(|k| k.repository.as_ref().map(|r| Url::parse(r).unwrap()))
+            .or_else(|| krate.repository)
             .clone();
         if let Some(repo) = repo_opt {
             if repo.host_str() == Some("github.com") {

--- a/_scraper/src/main.rs
+++ b/_scraper/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
             .krate
             .as_ref()
             .and_then(|k| k.repository.as_ref().map(|r| Url::parse(r).unwrap()))
-            .or_else(|| krate.repository)
+            .or(krate.repository)
             .clone();
         if let Some(repo) = repo_opt {
             if repo.host_str() == Some("github.com") {

--- a/posts/mlops.md
+++ b/posts/mlops.md
@@ -1,0 +1,12 @@
+---
+layout: crates.liquid
+title: MLOps
+permalink: /mlops
+data: { crate_tag: mlops, color: yellow }
+---
+
+MLOps (Machine Learning Operations) combines machine learning, DevOps, and data engineering to streamline and automate workflows for ML model development, deployment, and maintenance.
+
+Rust is gaining popularity in MLOps for its performance, safety, and reliability.
+It's used to build efficient ML infrastructure, data processing pipelines, vector databases, and model serving systems.
+Rust's speed and memory safety make it particularly suitable for high-performance, mission-critical MLOps components.


### PR DESCRIPTION
Following discussion with @anowell, I'm adding an MLOps category.

I'm adding a project I'm involved with (TensorZero) as well as two other projects I'm familiar with.

There was a small issue with the scraping tool: it skipped entries that only had a Github repository and no crates.io crate name. That has been resolved (`main.rs`).
