### PR TITLE
ADD: Crate mininn

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -234,6 +234,9 @@
 - name: metaheuristics
   topics: ["metaheuristics"]
 
+- name: mininn
+  topics: ["neural-networks"]
+
 - name: mop
   topics: ["metaheuristics", "scientific-computing"]
 


### PR DESCRIPTION
Adding [`mininn`](https://github.com/Pacatro/mininn) crate, a minimalist deep learning crate for Rust.