### PR TITLE
Add transformrs

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -417,6 +417,9 @@
 - name: tract
   topics: ["neural-networks"]
 
+- name: transformrs
+  topics: ["nlp"]
+
 - name: triton_grow
   repository: https://github.com/BradenEverson/triton
   topics: ["neural-networks"]


### PR DESCRIPTION
This PR suggests to add the `transformrs` crate (https://github.com/transformrs/transformrs). I should have checked "are we learning yet" earlier because there seem to be already two nice crates (https://github.com/anowell/are-we-learning-yet/pull/136/files), but let's see. The more options the more better I hope