### PR TITLE
Add `Kokoros`

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -459,6 +459,11 @@
 - name: ort
   topics: ["neural-networks"]
 
+- repository: 'https://github.com/lucasjinreal/Kokoros'
+  name: Kokoros
+  description: 'Kokoro in Rust. Insanely fast, realtime TTS with high quality you ever have.'
+  topics: ["nlp"]
+
 - name: Kyanite
   topics: ["neural-networks"]
 


### PR DESCRIPTION
Not fully in Rust (the project depends on Python), but still an honorable mention for `are-we-learning-yet` I suppose.