### PR TITLE
Add Rust-Cuda

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -361,6 +361,11 @@
 - name: rust-bert
   topics: ["nlp"]
 
+- name: rust-cuda
+  repository: https://github.com/Rust-GPU/Rust-CUDA
+  description: "Ecosystem of libraries and tools for writing and executing fast GPU code fully in Rust."
+  topics: ["gpu-computing"]
+
 - name: rusty-data
   documentation: https://athemathmo.github.io/rusty-data/
   topics: ["data-preprocessing"]


### PR DESCRIPTION
I saw issue #107. But I didn't see explanation and it was 4 year ago. The [Rust-Cuda](https://github.com/Rust-GPU/Rust-CUDA) repository seems active recently. They mention they're actively [`Rebooting the Rust CUDA project`](https://rust-gpu.github.io/blog/2025/01/27/rust-cuda-reboot/).