### PR TITLE
fix: updated outdated action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -26,26 +26,26 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v2
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: check
           args: --manifest-path _scraper/Cargo.toml
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: fmt
           args: --manifest-path _scraper/Cargo.toml --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: clippy
           args: --manifest-path _scraper/Cargo.toml -- -D warnings
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -73,20 +73,20 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Use daily cache of scraper data
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _tmp
           key: scraper-data-cache-${{ steps.date.outputs.date }}
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v2
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - name: Build Scraper
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: build
           args: --manifest-path _scraper/Cargo.toml --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,26 +26,26 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v2
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --manifest-path _scraper/Cargo.toml
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --manifest-path _scraper/Cargo.toml --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --manifest-path _scraper/Cargo.toml -- -D warnings
@@ -79,14 +79,14 @@ jobs:
           key: scraper-data-cache-${{ steps.date.outputs.date }}
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v2
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - name: Build Scraper
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --manifest-path _scraper/Cargo.toml --release


### PR DESCRIPTION
I incremented action versions until actionlint stopped throwing out of date errors.