### PR TITLE
Audit crates.yaml for dead, moved, and stale entries

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -47,9 +47,6 @@
 - name: blas
   topics: ["scientific-computing", "gpu-computing"]
 
-- name: blasoxide
-  topics: ["scientific-computing"]
-
 - name: burn
   topics: ["neural-networks"]
 
@@ -139,9 +136,6 @@
 - name: densearray
   topics: ["data-structures"]
 
-- name: deltaml
-  topics: ["neural-networks"]
-
 - name: dfdx
   topics:
     [
@@ -155,7 +149,7 @@
 - name: drug
   topics: ["neural-networks"]
 
-- name: egobox
+- name: egobox-ego
   topics: ["scientific-computing", "metaheuristics"]
 
 - name: em
@@ -166,13 +160,7 @@
   repository: https://github.com/calebwin/emu
   description: "A low-level modular, extensible GPGPU compute library with cross-platform support"
   documentation: https://calebwin.github.io/emu
-  topics: ["gpu-computing", "scientific-computing"]
-
-- name: emu_core
-  repository: https://github.com/calebwin/emu
-  description: "A wrapper type for storing/manipulating data on a GPU"
-  documentation: https://calebwin.github.io/emu
-  topics: ["data-structures"]
+  topics: ["gpu-computing", "scientific-computing", "data-structures"]
 
 - name: evo
   topics: ["metaheuristics"]
@@ -191,9 +179,6 @@
 
 - name: forester
   topics: ["decision-trees"]
-
-- name: genetic
-  topics: ["metaheuristics"]
 
 - name: GSL
   topics: ["scientific-computing"]
@@ -244,9 +229,6 @@
 - name: mininn
   topics: ["neural-networks"]
 
-- name: mop
-  topics: ["metaheuristics", "scientific-computing"]
-
 - name: nalgebra
   topics: ["scientific-computing"]
 
@@ -261,9 +243,6 @@
 
 - name: ndarray-stats
   topics: ["scientific-computing"]
-
-- name: ndsparse
-  topics: ["data-structures"]
 
 - name: neuroflow
   topics: ["neural-networks"]
@@ -314,10 +293,8 @@
   topics: ["neural-networks"]
 
 - name: qcgpu
+  repository: https://github.com/libtangle/qcgpu-version-0.1.0
   topics: ["scientific-computing"]
-
-- name: rds
-  topics: ["data-structures"]
 
 - name: rettle
   topics: ["data-preprocessing"]
@@ -364,11 +341,6 @@
 - name: rusty-data
   documentation: https://athemathmo.github.io/rusty-data/
   topics: ["data-preprocessing"]
-
-- name: rust-gpu
-  repository: https://github.com/rust-gpu/rust-gpu
-  description: "Making Rust a first-class language and ecosystem for GPU graphics & compute shaders"
-  topics: ["gpu-computing"]
 
 - name: rusty-machine
   topics: ["neural-networks", "linear-classifiers", "clustering"]
@@ -420,10 +392,6 @@
 - name: transformrs
   topics: ["nlp"]
 
-- name: triton_grow
-  repository: https://github.com/BradenEverson/triton
-  topics: ["neural-networks"]
-
 - name: tvm
   topics: ["neural-networks"]
 
@@ -445,9 +413,7 @@
   topics: ["neural-networks", "gpu-computing"]
 
 - name: luminal
-  topics: ["neural-networks"]
-
-- name: unda
+  repository: https://github.com/luminal-ai/luminal
   topics: ["neural-networks"]
 
 - name: custos
@@ -461,9 +427,6 @@
 
 - name: Kyanite
   topics: ["neural-networks"]
-
-- name: cubecl
-  topics: ["gpu-computing"]
 
 - name: krnl
   topics: ["gpu-computing"]
@@ -531,4 +494,14 @@
 - repository: https://github.com/YdrMaster/operators-rs
   description: "Multi-hardware support operator library"
   license: MIT
+  topics: ["neural-networks"]
+
+- repository: https://github.com/rust-gpu/rust-gpu
+  description: "Making Rust a first-class language and ecosystem for GPU graphics & compute shaders"
+  license: MIT OR Apache-2.0
+  topics: ["gpu-computing"]
+
+- repository: https://github.com/blackportal-ai/delta
+  description: "An open-source machine learning framework in Rust"
+  license: BSD-3-Clause
   topics: ["neural-networks"]

--- a/_layouts/crates.liquid
+++ b/_layouts/crates.liquid
@@ -31,12 +31,15 @@
             {%if crate.meta.documentation %}<a href="{{crate.meta.documentation}}">docs</a>{% endif %}
             ]
           </span>
+          {%if crate.repo.archived %}<span class="crate-archived">archived</span>{% endif %}
         {% elsif crate.repo %}
           {{crate.repo.name}}
           <span style="font-size: small; vertical-align:middle;">
             [
             {%if crate.repo.name %}<a href="https://github.com/{{crate.repo.name}}">repo</a>{% endif %}
             ]
+          </span>
+          {%if crate.repo.archived %}<span class="crate-archived">archived</span>{% endif %}
         {% endif %}
       </h3>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -179,6 +179,19 @@ a:hover .tile {
     white-space: nowrap;
 }
 
+.crate-archived {
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 11px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 8px;
+    border: 1px solid $status-red;
+    border-radius: 3px;
+    color: $status-red;
+}
+
 @media screen and (max-width: 47.9em) {
     .hide-xs { display: none; }
 }

--- a/_scraper/README.md
+++ b/_scraper/README.md
@@ -14,7 +14,7 @@ scraper <path/to/crates.yaml>
 Output is always written to `_data/crates_generated.yaml`, relative to the current directory,
 so run it from the repo root (`just scrape` does this for you).
 
-`GITHUB_TOKEN` must be set; the GitHub GraphQL API rejects unauthenticated requests.
+`GITHUB_TOKEN` must be set; unauthenticated GitHub API requests get rate limited almost immediately.
 
 ### Process details
 
@@ -27,7 +27,7 @@ The current process breaks down like this:
     - Successful responses are cached in the `_tmp` directory (failures are not cached, so they are retried on the next run).
     - Crate data comes from crates.io adhering to the [crates.io scraping policy](https://crates.io/policies#crawlers) by limiting to 1 req/sec.
       crates.io only reports a license per published version, so the license of the newest stable version is resolved alongside the crate.
-    - Repo data currently comes from Github via GraphQL API (where applicable). Supporting additional repo services would be a nice addition.
+    - Repo data currently comes from Github via the REST API (where applicable), and includes whether the owner has archived the repo. Supporting additional repo services would be a nice addition.
     - Cached data is always used if it is found. To force fetching new data, remove the cached file(s).
     - Errors with a particular crate are logged, and scraper will simply move onto the next crate.
 

--- a/_scraper/src/github.rs
+++ b/_scraper/src/github.rs
@@ -10,6 +10,8 @@ pub struct RepoData {
     pub name: String,
     pub stargazers_count: u32,
     pub last_commit: DateTime<Utc>,
+    // No serde default: an older cache entry must miss and refetch rather than read as `false`.
+    pub archived: bool,
 }
 
 // octocrab's own Display for a failed request is just "GitHub"; the status and
@@ -52,6 +54,7 @@ impl Github {
             last_commit: repository
                 .pushed_at
                 .ok_or_else(|| anyhow!("no push timestamp returned"))?,
+            archived: repository.archived.unwrap_or(false),
         })
     }
 

--- a/_scraper/src/main.rs
+++ b/_scraper/src/main.rs
@@ -9,7 +9,13 @@ use crates::CratesIo;
 use data::{GeneratedCrateInfo, InputCrateInfo};
 use github::Github;
 use std::env;
+use url::Url;
 use util::{read_yaml, write_yaml};
+
+// Some crates.io repository URLs carry a `www.` prefix, which would otherwise skip scraping.
+fn is_github(repo: &Url) -> bool {
+    matches!(repo.host_str(), Some("github.com" | "www.github.com"))
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -45,7 +51,7 @@ async fn main() -> Result<()> {
         entry.apply_overrides(&krate);
 
         if let Some(repo) = entry.repository(&krate)
-            && repo.host_str() == Some("github.com")
+            && is_github(&repo)
         {
             let mut parts = repo.path().trim_start_matches('/').split('/');
             match (parts.next(), parts.next()) {


### PR DESCRIPTION
## Summary

`_data/crates.yaml` had accumulated entries that no longer resolve, and the site had no way to tell "this project is gone" from "this project just isn't on GitHub anymore". This triages all 154 entries against the crates.io and GitHub REST APIs.

Default is keep. Delisting required both an unreachable repo *and* an abandoned crate.

## Removed (7)

| Entry | Repo | Crate evidence |
| --- | --- | --- |
| `blasoxide` | owner account deleted | last publish 2019; crates.io owner is a ghosted account |
| `genetic` | repo deleted | last publish 2015 |
| `mop` | repo deleted | last publish 2020 |
| `ndsparse` | repo deleted | all 18 versions yanked |
| `rds` | repo deleted | last publish 2016 |
| `triton_grow` | repo deleted | renamed to `unda` same author/same day; 70 of 71 versions yanked |
| `unda` | repo deleted | last publish 2024-02; 10 of 13 versions yanked |

Relocations were searched for first — other forges, the crate's `homepage`/`documentation`, the latest published version's own `Cargo.toml`, web search. Three candidates were checked and rejected: `thecooldrop/blasoxide` is a third-party copy pinned at the last published version whose `Cargo.toml` still names the dead upstream repo, `atlv24/unda` is an inactive fork with no releases, and the `unda-ml` org cited by search results does not exist.

## Corrected in place (5)

A missing repo is a correction, not a delisting:

- **`deltaml`** — removed from crates.io entirely, but active at `blackportal-ai/delta` (its README still badges the `deltaml` crate). Now a repository-only entry.
- **`luminal`**, **`qcgpu`** — no `repository` on crates.io.
- **`rust-gpu`** — the crates.io crate is a name reservation described as "rust-gpu reserved crate, do not use", all versions yanked. Now repository-only.
- **`egobox` → `egobox-ego`** — `egobox` is a Python binding with every version yanked; `egobox-ego` is the Rust entry point of the same project.

`qcgpu` points at `libtangle/qcgpu-version-0.1.0`, not `libtangle/qcgpu`. The latter is a Python project that reused the name — GitHub redirects a renamed repo *name*, so the `qcgpu-rust` redirect crosses projects rather than tracking a rename.

Also deduplicated `cubecl` (listed twice) and `emu_core` (listed twice with different topic sets, now merged).

## Dormant entries are kept, and unlabeled

67 entries have had no publish or commit since 2023. All kept, none labeled. Age alone is not evidence of abandonment — a crate can be finished and still maintained — and `update_score` already sinks inactive entries. The cards already show `Last Commit` and `Last Published`.

The one maintenance signal the site now asserts is `archived`, because repo owners set it themselves. `RepoData` picks it up and topic pages render a badge. 10 entries carry it.

## Two incidental bugs

- The scraper matched `host_str() == "github.com"` exactly, so any crates.io repository with a `www.` prefix silently skipped repo scraping. This cost `em` its repo metadata.
- The repo-only branch of `crates.liquid` opened a `<span>` it never closed, on all 13 such cards.

## Verification

`just check` passes (clippy `-D warnings` + `cargo fmt --check`). `just scrape` completes over all 145 entries with zero errors, and `cobalt build` succeeds.

## Not addressed

- `tvm`, `leaf`, and `juice` point at stale crates inside live repos, so their scores ride on tiny download counts despite active development. A scoring question, not a listing one.
- `accel` and `Kyanite` are on GitLab and still score on crates.io data alone — the scraper only fetches repo metadata for `github.com`.
- A modern, maintained `genetic-rs` crate exists by a different author; adding it would be a new listing.
